### PR TITLE
update to use 'terraform-aws-ssm-agent' module + fix tailscale config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,33 +31,30 @@ Here is an example of using this module:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 1.2 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | >= 0.13.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | >= 0.13.6 |
 | <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_label"></a> [instance\_label](#module\_instance\_label) | git::https://github.com/cloudposse/terraform-null-label.git | tags/0.21.0 |
+| <a name="module_tailscale_subnet_router"></a> [tailscale\_subnet\_router](#module\_tailscale\_subnet\_router) | git::https://github.com/masterpointio/terraform-aws-ssm-agent.git | tags/0.15.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
-| [aws_launch_template.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.allow_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [tailscale_tailnet_key.default](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key) | resource |
 | [template_file.userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
@@ -65,41 +62,46 @@ Here is an example of using this module:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_advertise_routes"></a> [advertise\_routes](#input\_advertise\_routes) | The routes (expressed as CIDRs) to advertise as part of this tailscale relay instance. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ] | `list(string)` | `[]` | no |
-| <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the tailscale relay instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates. | `string` | `""` | no |
-| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a Public IP with the tailscale relay instance. Recommended against. | `bool` | `false` | no |
+| <a name="input_advertise_routes"></a> [advertise\_routes](#input\_advertise\_routes) | The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ] | `list(string)` | `[]` | no |
+| <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the  Tailscale Subnet Router EC2 instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates. | `string` | `""` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_authkey"></a> [authkey](#input\_authkey) | The pre-auth key retrieved from the tailscale console which allows to authenticate a new device without an interactive login. | `string` | n/a | yes |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_create_run_shell_document"></a> [create\_run\_shell\_document](#input\_create\_run\_shell\_document) | Whether or not to create the SSM-SessionManagerRunShell SSM Document. | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | The name of the IAM instance profile to associate with the tailscale relay instance. | `string` | `null` | no |
+| <a name="input_ephemeral"></a> [ephemeral](#input\_ephemeral) | Indicates if the key is ephemeral. | `bool` | `false` | no |
+| <a name="input_expiry"></a> [expiry](#input\_expiry) | The expiry of the auth key in seconds. | `number` | `3600` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of tailscale relay instances you would like to deploy. | `number` | `1` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for the tailscale relay instance. | `string` | `"t3.nano"` | no |
-| <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | The name of the key-pair to associate with the tailscale relay instance. | `string` | `null` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of  Tailscale Subnet Router EC2 instances you would like to deploy. | `number` | `1` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for the Tailscale Subnet Router EC2 instance. | `string` | `"t3.nano"` | no |
+| <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | The name of the key-pair to associate with the Tailscale Subnet Router EC2 instance. | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_preauthorized"></a> [preauthorized](#input\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default. | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_reusable"></a> [reusable](#input\_reusable) | Indicates if the key is reusable or single-use. | `bool` | `true` | no |
+| <a name="input_session_logging_enabled"></a> [session\_logging\_enabled](#input\_session\_logging\_enabled) | To enable CloudWatch and S3 session logging or not. Note this does not apply to SSH sessions as AWS cannot log those sessions. | `bool` | `true` | no |
+| <a name="input_session_logging_kms_key_alias"></a> [session\_logging\_kms\_key\_alias](#input\_session\_logging\_kms\_key\_alias) | Alias name for `session_logging` KMS Key. This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset, (2) `session_logging_encryption_enabled` = true. | `string` | `"alias/session_logging"` | no |
+| <a name="input_session_logging_ssm_document_name"></a> [session\_logging\_ssm\_document\_name](#input\_session\_logging\_ssm\_document\_name) | Name for `session_logging` SSM document. This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true, (2) `create_run_shell_document` = true. | `string` | `"SSM-SessionManagerRunShell-Tailscale"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The Subnet IDs which the tailscale relay instance will run in. These *should* be private subnets. | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The Subnet IDs which the Tailscale Subnet Router EC2 instance will run in. These *should* be private subnets. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC which the tailscale relay instance will run in. | `string` | n/a | yes |
-| <a name="input_yum_repo"></a> [yum\_repo](#input\_yum\_repo) | The yum repo used to download tailscale. Useful if not using the Amazon Linux 2 AMI. | `string` | `"https://pkgs.tailscale.com/stable/amazon-linux/2/tailscale.repo"` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user\_data to use for the Tailscale Subnet Router EC2 instance. You can use this to automate installation of all the required command line tools. | `string` | `""` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC which the Tailscale Subnet Router EC2 instance will run in. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_autoscaling_group_id"></a> [autoscaling\_group\_id](#output\_autoscaling\_group\_id) | The ID of the SSM Agent Autoscaling Group. |
-| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | The name tag value of the Bastion instance. |
-| <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | The ID of the SSM Agent Launch Template. |
-| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the SSM Agent Security Group. |
+| <a name="output_autoscaling_group_id"></a> [autoscaling\_group\_id](#output\_autoscaling\_group\_id) | The ID of the Tailscale Subnet Router EC2 instance Autoscaling Group. |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | The name tag value of the Tailscale Subnet Router EC2 instance. |
+| <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | The ID of the Tailscale Subnet Router EC2 instance Launch Template. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the Tailscale Subnet Router EC2 instance Security Group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -1,123 +1,44 @@
-module "instance_label" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
-  name   = "tailscale-relay"
-
-  additional_tag_map = {
-    propagate_at_launch = "true"
-  }
-
-  context = module.this.context
-}
-
 locals {
-  tailscale_tags = join(",", [
-    for t in values(module.this.tags) : replace("tag:${t}", "_", "-")
-  ])
-}
-
-# Most recent Amazon Linux 2 AMI
-data "aws_ami" "amazon_linux_2" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm*"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
+  tailscale_tags = [for k, v in module.this.tags : "tag:${v}" if k == "Name"]
 }
 
 data "template_file" "userdata" {
   template = file("${path.module}/userdata.sh.tpl")
   vars = {
-    yum_repo = var.yum_repo
     routes   = join(",", var.advertise_routes)
-    tags     = local.tailscale_tags
-    authkey  = var.authkey
+    authkey  = tailscale_tailnet_key.default.key
     hostname = module.this.id
   }
 }
 
-resource "aws_launch_template" "default" {
-  name_prefix   = module.this.id
-  image_id      = var.ami != "" ? var.ami : data.aws_ami.amazon_linux_2.id
-  instance_type = var.instance_type
-  key_name      = var.key_pair_name
-  user_data     = base64encode(data.template_file.userdata.rendered)
+module "tailscale_subnet_router" {
+  source = "git::https://github.com/masterpointio/terraform-aws-ssm-agent.git?ref=tags/0.15.1"
 
-  monitoring {
-    enabled = true
-  }
+  context = module.this.context
+  tags    = module.this.tags
 
-  network_interfaces {
-    associate_public_ip_address = var.associate_public_ip_address
-    delete_on_termination       = true
-    security_groups             = [aws_security_group.default.id]
-  }
+  vpc_id                    = var.vpc_id
+  subnet_ids                = var.subnet_ids
+  key_pair_name             = var.key_pair_name
+  create_run_shell_document = var.create_run_shell_document
 
-  iam_instance_profile {
-    name = var.iam_instance_profile
-  }
+  session_logging_kms_key_alias     = var.session_logging_kms_key_alias
+  session_logging_enabled           = var.session_logging_enabled
+  session_logging_ssm_document_name = var.session_logging_ssm_document_name
 
-  tag_specifications {
-    resource_type = "instance"
-    tags          = module.this.tags
-  }
+  ami            = var.ami
+  instance_type  = var.instance_type
+  instance_count = var.instance_count
 
-  tag_specifications {
-    resource_type = "volume"
-    tags          = module.this.tags
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
+  user_data = base64encode(length(var.user_data) > 0 ? var.user_data : data.template_file.userdata.rendered)
 }
 
-resource "aws_autoscaling_group" "default" {
-  name = module.instance_label.id
-  tags = module.instance_label.tags_as_list_of_maps
+resource "tailscale_tailnet_key" "default" {
+  reusable      = var.reusable
+  ephemeral     = var.ephemeral
+  preauthorized = var.preauthorized
+  expiry        = var.expiry
 
-  launch_template {
-    id      = aws_launch_template.default.id
-    version = "$Latest"
-  }
-
-  max_size         = var.instance_count
-  min_size         = var.instance_count
-  desired_capacity = var.instance_count
-
-  vpc_zone_identifier = var.subnet_ids
-
-  default_cooldown          = 180
-  health_check_grace_period = 180
-  health_check_type         = "EC2"
-
-  termination_policies = [
-    "OldestLaunchConfiguration",
-  ]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group" "default" {
-  vpc_id      = var.vpc_id
-  name        = module.this.id
-  description = "Allow ALL egress from Tailscale node."
-  tags        = module.this.tags
-}
-
-resource "aws_security_group_rule" "allow_all_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.default.id
+  # A device is automatically tagged when it is authenticated with this key.
+  tags = local.tailscale_tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "instance_name" {
   value       = module.this.id
-  description = "The name tag value of the Bastion instance."
+  description = "The name tag value of the Tailscale Subnet Router EC2 instance."
 }
 
 output "security_group_id" {
-  value       = aws_security_group.default.id
-  description = "The ID of the SSM Agent Security Group."
+  value       = module.tailscale_subnet_router.security_group_id
+  description = "The ID of the Tailscale Subnet Router EC2 instance Security Group."
 }
 
 output "launch_template_id" {
-  value       = aws_launch_template.default.id
-  description = "The ID of the SSM Agent Launch Template."
+  value       = module.tailscale_subnet_router.launch_template_id
+  description = "The ID of the Tailscale Subnet Router EC2 instance Launch Template."
 }
 
 output "autoscaling_group_id" {
-  value       = aws_autoscaling_group.default.id
-  description = "The ID of the SSM Agent Autoscaling Group."
+  value       = module.tailscale_subnet_router.autoscaling_group_id
+  description = "The ID of the Tailscale Subnet Router EC2 instance Autoscaling Group."
 }

--- a/userdata.sh.tpl
+++ b/userdata.sh.tpl
@@ -1,14 +1,15 @@
 #!/bin/bash -ex
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-# Install tailscale
-sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo ${yum_repo}
-sudo yum install -y tailscale
-
 # Enable ip_forward to allow advertising routes
 echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.conf
+echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p /etc/sysctl.conf
+
+# Install tailscale
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://pkgs.tailscale.com/stable/amazon-linux/2/tailscale.repo
+sudo yum install -y tailscale
 
 # Setup tailscale
 sudo systemctl enable --now tailscaled
@@ -19,6 +20,5 @@ sleep 5
 # Start tailscale
 sudo tailscale up \
     --advertise-routes=${routes} \
-    --advertise-tags=${tags} \
     --authkey=${authkey} \
     --hostname=${hostname}

--- a/variables.tf
+++ b/variables.tf
@@ -1,62 +1,103 @@
+#################################
+## Subnet Router EC2 Instance ##
+###############################
+
 variable "vpc_id" {
   type        = string
-  description = "The ID of the VPC which the tailscale relay instance will run in."
+  description = "The ID of the VPC which the Tailscale Subnet Router EC2 instance will run in."
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "The Subnet IDs which the tailscale relay instance will run in. These *should* be private subnets."
+  description = "The Subnet IDs which the Tailscale Subnet Router EC2 instance will run in. These *should* be private subnets."
 }
 
-variable "instance_type" {
-  default     = "t3.nano"
+variable "create_run_shell_document" {
+  default     = true
+  type        = bool
+  description = "Whether or not to create the SSM-SessionManagerRunShell SSM Document."
+}
+
+variable "session_logging_enabled" {
+  default     = true
+  type        = bool
+  description = "To enable CloudWatch and S3 session logging or not. Note this does not apply to SSH sessions as AWS cannot log those sessions."
+}
+
+variable "session_logging_kms_key_alias" {
+  default     = "alias/session_logging"
   type        = string
-  description = "The instance type to use for the tailscale relay instance."
+  description = "Alias name for `session_logging` KMS Key. This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset, (2) `session_logging_encryption_enabled` = true."
 }
 
-variable "ami" {
-  default     = ""
+
+variable "session_logging_ssm_document_name" {
+  default     = "SSM-SessionManagerRunShell-Tailscale"
   type        = string
-  description = "The AMI to use for the tailscale relay instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates."
-}
-
-variable "instance_count" {
-  default     = 1
-  type        = number
-  description = "The number of tailscale relay instances you would like to deploy."
+  description = "Name for `session_logging` SSM document. This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true, (2) `create_run_shell_document` = true."
 }
 
 variable "key_pair_name" {
   default     = null
   type        = string
-  description = "The name of the key-pair to associate with the tailscale relay instance."
+  description = "The name of the key-pair to associate with the Tailscale Subnet Router EC2 instance."
 }
 
-variable "associate_public_ip_address" {
-  default     = false
-  type        = bool
-  description = "Whether to associate a Public IP with the tailscale relay instance. Recommended against."
-}
-
-variable "iam_instance_profile" {
-  default     = null
+variable "user_data" {
+  default     = ""
   type        = string
-  description = "The name of the IAM instance profile to associate with the tailscale relay instance."
+  description = "The user_data to use for the Tailscale Subnet Router EC2 instance. You can use this to automate installation of all the required command line tools."
 }
 
-variable "yum_repo" {
-  default     = "https://pkgs.tailscale.com/stable/amazon-linux/2/tailscale.repo"
+variable "ami" {
+  default     = ""
   type        = string
-  description = "The yum repo used to download tailscale. Useful if not using the Amazon Linux 2 AMI."
+  description = "The AMI to use for the  Tailscale Subnet Router EC2 instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates."
 }
+
+variable "instance_type" {
+  default     = "t3.nano"
+  type        = string
+  description = "The instance type to use for the Tailscale Subnet Router EC2 instance."
+}
+
+variable "instance_count" {
+  default     = 1
+  type        = number
+  description = "The number of  Tailscale Subnet Router EC2 instances you would like to deploy."
+}
+
+################
+## Tailscale ##
+##############
 
 variable "advertise_routes" {
   default     = []
   type        = list(string)
-  description = "The routes (expressed as CIDRs) to advertise as part of this tailscale relay instance. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ]"
+  description = "The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ]"
 }
 
-variable "authkey" {
-  type        = string
-  description = "The pre-auth key retrieved from the tailscale console which allows to authenticate a new device without an interactive login."
+variable "expiry" {
+  default     = 3600
+  type        = number
+  description = "The expiry of the auth key in seconds."
+}
+
+
+variable "preauthorized" {
+  default     = true
+  type        = bool
+  description = "Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default."
+}
+
+variable "ephemeral" {
+  default     = false
+  type        = bool
+  description = "Indicates if the key is ephemeral."
+}
+
+variable "reusable" {
+  default     = true
+  type        = bool
+  description = " Indicates if the key is reusable or single-use."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.2"
+      version = ">= 1.2"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.0"
+      version = ">= 2.0"
+    }
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = ">= 0.13.6"
     }
   }
 }


### PR DESCRIPTION
## what
* Migrate this `tailscale` module to use our `'terraform-aws-ssm-agent` module as a base.
* Add tailscale resources required for subnet router configuration.

## why
* Avoid double work on similar group of resources to run a EC2 instance with SSM agent.
* Extend the module with tailscale resources where possible.

## references
* N/A

