### PR TITLE
chore: bump 'ssm-agent' module + providers version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 ## Usage
 
-
 Here's how to invoke this example module in your projects
 
 ```hcl
 module "example" {
-  source = "git::https://github.com/masterpointio/terraform-aws-tailscale.git?ref=tags/X.X.X"
+  source  = "masterpointio/ssm-agent/aws"
+  version = "0.16.1"
+
+  vpc_id           = var.vpc_id
+  advertise_routes = [var.vpc_cidr_block]
+  subnet_ids       = var.private_subnet_ids
+  key_pair_name    = var.tailscale_existing_ssh_key_name
 }
 ```
 
@@ -30,24 +35,24 @@ Here is an example of using this module:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | >= 0.13.6 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | >= 0.13.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | >= 0.13.6 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | >= 0.13.7 |
 | <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tailscale_subnet_router"></a> [tailscale\_subnet\_router](#module\_tailscale\_subnet\_router) | git::https://github.com/masterpointio/terraform-aws-ssm-agent.git | tags/0.15.1 |
+| <a name="module_tailscale_subnet_router"></a> [tailscale\_subnet\_router](#module\_tailscale\_subnet\_router) | masterpointio/ssm-agent/aws | 0.16.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,24 +3,30 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.17.0"
+  source  = "cloudposse/vpc/aws"
+  version = "2.1.0"
 
-  cidr_block = "172.16.0.0/16"
-  attributes = var.attributes
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.name
+
+  ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context
 }
 
 module "subnets" {
-  source = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.32.0"
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "2.3.0"
 
-  attributes           = var.attributes
-  availability_zones   = var.availability_zones
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = false
-  nat_instance_enabled = true
+  namespace = var.namespace
+  stage     = var.stage
+
+  availability_zones = var.availability_zones
+  vpc_id             = module.vpc.vpc_id
+  igw_id             = [module.vpc.igw_id]
+  ipv4_cidr_block    = [module.vpc.vpc_cidr_block]
+  ipv6_enabled       = var.ipv6_enabled
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,8 @@ data "template_file" "userdata" {
 }
 
 module "tailscale_subnet_router" {
-  source = "git::https://github.com/masterpointio/terraform-aws-ssm-agent.git?ref=tags/0.15.1"
+  source  = "masterpointio/ssm-agent/aws"
+  version = "0.16.1"
 
   context = module.this.context
   tags    = module.this.tags

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.0"
     }
     local = {
       source  = "hashicorp/local"
@@ -16,7 +16,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = ">= 0.13.6"
+      version = ">= 0.13.7"
     }
   }
 }


### PR DESCRIPTION
## what
* Update `ssm-agent` module version. 
* Update providers version contsraints.

## why
* Support the latest module version for S3 logs bucket.

## references
* N/A