### PR TITLE
fix: replace data source of archived provider with 'templatefile' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 # terraform-aws-tailscale [![Latest Release](https://img.shields.io/github/release/masterpointio/terraform-aws-tailscale.svg)](https://github.com/masterpointio/terraform-aws-tailscale/releases/latest)
 
-[![README Header][readme_header_img]][readme_header_link]
-
-
 This is a Terraform Module to create a simple, autoscaled [Tailscale Subnet Router](https://tailscale.com/kb/1019/subnets/) on EC2 instance along with generated auth key, and its corresponding IAM resources. The instance should cycle itself on a schedule.
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
@@ -46,7 +43,6 @@ Here is an example of using this module:
 | Name | Version |
 |------|---------|
 | <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | >= 0.13.7 |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
@@ -60,15 +56,14 @@ Here is an example of using this module:
 | Name | Type |
 |------|------|
 | [tailscale_tailnet_key.default](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key) | resource |
-| [template_file.userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_advertise_routes"></a> [advertise\_routes](#input\_advertise\_routes) | The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ] | `list(string)` | `[]` | no |
-| <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the  Tailscale Subnet Router EC2 instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates. | `string` | `""` | no |
+| <a name="input_advertise_routes"></a> [advertise\_routes](#input\_advertise\_routes) | The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router.<br>  Example: ["10.0.2.0/24", "0.0.1.0/24"] | `list(string)` | `[]` | no |
+| <a name="input_ami"></a> [ami](#input\_ami) | The AMI to use for the Tailscale Subnet Router EC2 instance.<br>  If not provided, the latest Amazon Linux 2 AMI will be used.<br>  Note: This will update periodically as AWS releases updates to their AL2 AMI.<br>  Pin to a specific AMI if you would like to avoid these updates. | `string` | `""` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_create_run_shell_document"></a> [create\_run\_shell\_document](#input\_create\_run\_shell\_document) | Whether or not to create the SSM-SessionManagerRunShell SSM Document. | `bool` | `true` | no |
@@ -79,7 +74,7 @@ Here is an example of using this module:
 | <a name="input_ephemeral"></a> [ephemeral](#input\_ephemeral) | Indicates if the key is ephemeral. | `bool` | `false` | no |
 | <a name="input_expiry"></a> [expiry](#input\_expiry) | The expiry of the auth key in seconds. | `number` | `7776000` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of  Tailscale Subnet Router EC2 instances you would like to deploy. | `number` | `1` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of Tailscale Subnet Router EC2 instances you would like to deploy. | `number` | `1` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for the Tailscale Subnet Router EC2 instance. | `string` | `"t3.nano"` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | The name of the key-pair to associate with the Tailscale Subnet Router EC2 instance. | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
@@ -91,14 +86,14 @@ Here is an example of using this module:
 | <a name="input_preauthorized"></a> [preauthorized](#input\_preauthorized) | Determines whether or not the machines authenticated by the key will be authorized for the tailnet by default. | `bool` | `true` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_reusable"></a> [reusable](#input\_reusable) | Indicates if the key is reusable or single-use. | `bool` | `true` | no |
-| <a name="input_session_logging_enabled"></a> [session\_logging\_enabled](#input\_session\_logging\_enabled) | To enable CloudWatch and S3 session logging or not. Note this does not apply to SSH sessions as AWS cannot log those sessions. | `bool` | `true` | no |
-| <a name="input_session_logging_kms_key_alias"></a> [session\_logging\_kms\_key\_alias](#input\_session\_logging\_kms\_key\_alias) | Alias name for `session_logging` KMS Key. This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset, (2) `session_logging_encryption_enabled` = true. | `string` | `"alias/session_logging"` | no |
-| <a name="input_session_logging_ssm_document_name"></a> [session\_logging\_ssm\_document\_name](#input\_session\_logging\_ssm\_document\_name) | Name for `session_logging` SSM document. This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true, (2) `create_run_shell_document` = true. | `string` | `"SSM-SessionManagerRunShell-Tailscale"` | no |
+| <a name="input_session_logging_enabled"></a> [session\_logging\_enabled](#input\_session\_logging\_enabled) | To enable CloudWatch and S3 session logging or not.<br>  Note this does not apply to SSH sessions as AWS cannot log those sessions. | `bool` | `true` | no |
+| <a name="input_session_logging_kms_key_alias"></a> [session\_logging\_kms\_key\_alias](#input\_session\_logging\_kms\_key\_alias) | Alias name for `session_logging` KMS Key.<br>  This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset,<br>  (2) `session_logging_encryption_enabled` = true. | `string` | `"alias/session_logging"` | no |
+| <a name="input_session_logging_ssm_document_name"></a> [session\_logging\_ssm\_document\_name](#input\_session\_logging\_ssm\_document\_name) | Name for `session_logging` SSM document.<br>  This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true,<br>  (2) `create_run_shell_document` = true. | `string` | `"SSM-SessionManagerRunShell-Tailscale"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The Subnet IDs which the Tailscale Subnet Router EC2 instance will run in. These *should* be private subnets. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user\_data to use for the Tailscale Subnet Router EC2 instance. You can use this to automate installation of all the required command line tools. | `string` | `""` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user\_data to use for the Tailscale Subnet Router EC2 instance.<br>  You can use this to automate installation of all the required command line tools. | `string` | `""` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC which the Tailscale Subnet Router EC2 instance will run in. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,10 @@
 locals {
   tailscale_tags = [for k, v in module.this.tags : "tag:${v}" if k == "Name"]
-}
-
-data "template_file" "userdata" {
-  template = file("${path.module}/userdata.sh.tpl")
-  vars = {
+  userdata = templatefile("${path.module}/userdata.sh.tpl", {
     routes   = join(",", var.advertise_routes)
     authkey  = tailscale_tailnet_key.default.key
     hostname = module.this.id
-  }
+  })
 }
 
 module "tailscale_subnet_router" {
@@ -31,7 +27,7 @@ module "tailscale_subnet_router" {
   instance_type  = var.instance_type
   instance_count = var.instance_count
 
-  user_data = base64encode(length(var.user_data) > 0 ? var.user_data : data.template_file.userdata.rendered)
+  user_data = base64encode(length(var.user_data) > 0 ? var.user_data : local.userdata)
 }
 
 resource "tailscale_tailnet_key" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,20 +21,31 @@ variable "create_run_shell_document" {
 variable "session_logging_enabled" {
   default     = true
   type        = bool
-  description = "To enable CloudWatch and S3 session logging or not. Note this does not apply to SSH sessions as AWS cannot log those sessions."
+  description = <<EOF
+  To enable CloudWatch and S3 session logging or not.
+  Note this does not apply to SSH sessions as AWS cannot log those sessions.
+  EOF
 }
 
 variable "session_logging_kms_key_alias" {
   default     = "alias/session_logging"
   type        = string
-  description = "Alias name for `session_logging` KMS Key. This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset, (2) `session_logging_encryption_enabled` = true."
+  description = <<EOF
+  Alias name for `session_logging` KMS Key.
+  This is only applied if 2 conditions are met: (1) `session_logging_kms_key_arn` is unset,
+  (2) `session_logging_encryption_enabled` = true.
+  EOF
 }
 
 
 variable "session_logging_ssm_document_name" {
   default     = "SSM-SessionManagerRunShell-Tailscale"
   type        = string
-  description = "Name for `session_logging` SSM document. This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true, (2) `create_run_shell_document` = true."
+  description = <<EOF
+  Name for `session_logging` SSM document.
+  This is only applied if 2 conditions are met: (1) `session_logging_enabled` = true,
+  (2) `create_run_shell_document` = true.
+  EOF
 }
 
 variable "key_pair_name" {
@@ -46,13 +57,21 @@ variable "key_pair_name" {
 variable "user_data" {
   default     = ""
   type        = string
-  description = "The user_data to use for the Tailscale Subnet Router EC2 instance. You can use this to automate installation of all the required command line tools."
+  description = <<EOF
+  The user_data to use for the Tailscale Subnet Router EC2 instance.
+  You can use this to automate installation of all the required command line tools.
+  EOF
 }
 
 variable "ami" {
   default     = ""
   type        = string
-  description = "The AMI to use for the  Tailscale Subnet Router EC2 instance. If not provided, the latest Amazon Linux 2 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2 AMI. Pin to a specific AMI if you would like to avoid these updates."
+  description = <<EOF
+  The AMI to use for the Tailscale Subnet Router EC2 instance.
+  If not provided, the latest Amazon Linux 2 AMI will be used.
+  Note: This will update periodically as AWS releases updates to their AL2 AMI.
+  Pin to a specific AMI if you would like to avoid these updates.
+  EOF
 }
 
 variable "instance_type" {
@@ -64,7 +83,7 @@ variable "instance_type" {
 variable "instance_count" {
   default     = 1
   type        = number
-  description = "The number of  Tailscale Subnet Router EC2 instances you would like to deploy."
+  description = "The number of Tailscale Subnet Router EC2 instances you would like to deploy."
 }
 
 ################
@@ -74,7 +93,14 @@ variable "instance_count" {
 variable "advertise_routes" {
   default     = []
   type        = list(string)
-  description = "The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router. e.g. [ '10.0.2.0/24', '10.0.1.0/24 ]"
+  description = <<EOF
+  The routes (expressed as CIDRs) to advertise as part of the Tailscale Subnet Router.
+  Example: ["10.0.2.0/24", "0.0.1.0/24"]
+  EOF
+  validation {
+    condition     = can([for route in var.advertise_routes : cidrsubnet(route, 0, 0)])
+    error_message = "All elements in the list must be valid CIDR blocks."
+  }
 }
 
 variable "expiry" {
@@ -82,7 +108,6 @@ variable "expiry" {
   type        = number
   description = "The expiry of the auth key in seconds."
 }
-
 
 variable "preauthorized" {
   default     = true


### PR DESCRIPTION
## what
* Replace the data source of the archived [template](https://registry.terraform.io/providers/hashicorp/template/latest) provider with `templatefile` function.

## why
* The provider is extremely old, and Darwin is not supported.

## references
* N/A, found that out during internal works.

