### PR TITLE
chore: bump dep version to allow ipv6 space egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Here is an example of using this module:
 
 | Name                                                                                                     | Source                      | Version |
 | -------------------------------------------------------------------------------------------------------- | --------------------------- | ------- |
-| <a name="module_tailscale_subnet_router"></a> [tailscale_subnet_router](#module_tailscale_subnet_router) | masterpointio/ssm-agent/aws | 1.0.0   |
+| <a name="module_tailscale_subnet_router"></a> [tailscale_subnet_router](#module_tailscale_subnet_router) | masterpointio/ssm-agent/aws | 1.1.0   |
 | <a name="module_this"></a> [this](#module_this)                                                          | cloudposse/label/null       | 0.25.0  |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
 
 module "tailscale_subnet_router" {
   source  = "masterpointio/ssm-agent/aws"
-  version = "1.0.0"
+  version = "1.1.0"
 
   context = module.this.context
   tags    = module.this.tags


### PR DESCRIPTION
## what
* Updated the SSM agent module (https://github.com/masterpointio/terraform-aws-ssm-agent) to allow egress for all ipv6 spaces, bump this dependency in this module as well

## references
* Follow up to the PR in the SSM agent module + issue (https://github.com/masterpointio/terraform-aws-ssm-agent/pull/22) (https://github.com/masterpointio/terraform-aws-ssm-agent/issues/21), brought up by @mheffner (https://github.com/masterpointio/terraform-aws-ssm-agent/issues/21#issuecomment-2113496609)

