### PR TITLE
chore: update ssm agent dependency version for al2023 upgrade

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     tailscale = {
       source  = "tailscale/tailscale"

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ locals {
 
 module "tailscale_subnet_router" {
   source  = "masterpointio/ssm-agent/aws"
-  version = "1.1.0"
+  version = "1.2.0"
 
   context = module.this.context
   tags    = module.this.tags


### PR DESCRIPTION
Update the SSM Agent instance module used for the subnet router, which upgrades to Amazon Linux 2023 from Amazon Linux 2 (https://github.com/masterpointio/terraform-aws-ssm-agent/pull/24)
![image](https://github.com/masterpointio/terraform-aws-tailscale/assets/35899715/a23952eb-d4b9-41ba-93c5-a13fe7250f1a)


Also update the AWS provider version in the example because the same SSM agent downstream module uses v5 (https://github.com/masterpointio/terraform-aws-ssm-agent/blob/main/versions.tf#L7)