### PR TITLE
feat: adds release-please for automated releases

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,11 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v4
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@86b68ffae610a05105e90b1f52ad8c549ef482c2
 
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,13 +21,6 @@ jobs:
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
 
-  tf-fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Terraform CLI
-        uses: hashicorp/setup-terraform@v3
-      - run: terraform fmt -check -recursive
-
   conventional-title:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,9 @@
 name: Lint
 
+concurrency:
+  group: lint-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on: pull_request
 
 permissions:
@@ -9,13 +13,24 @@ permissions:
   pull-requests: read
 
 jobs:
-  lint:
+  trunk-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
+
+  tf-fmt:
+    runs-on: ubuntu-latest
+    steps:
       - name: Set up Terraform CLI
         uses: hashicorp/setup-terraform@v3
       - run: terraform fmt -check -recursive
+
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f
         with:
           release-type: terraform-module

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: terraform-module

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@v1
+        uses: trunk-io/trunk-action/upgrade@d5b1b61d0beee562512f530a278b6a2931fba857
         with:
           base: main
           reviewers: "@masterpointio/masterpoint-internal"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,7 +16,7 @@ runtimes:
 lint:
   enabled:
     - actionlint@1.7.1
-    - checkov@3.2.217
+    - checkov@3.2.219
     - git-diff-check
     - markdownlint@0.41.0
     - prettier@3.3.3
@@ -25,7 +25,7 @@ lint:
     - terrascan@1.19.1
     - tflint@0.52.0
     - trivy@0.54.1
-    - trufflehog@3.80.5
+    - trufflehog@3.81.7
     - yamllint@1.35.1
   ignore:
     - linters: [shellcheck]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,6 +15,8 @@ runtimes:
     - python@3.10.8
 lint:
   enabled:
+    - tofu@1.8.1
+    - terraform@1.1.0
     - actionlint@1.7.1
     - checkov@3.2.219
     - git-diff-check


### PR DESCRIPTION
## what
* Adds a new workflow for [Release Please](https://github.com/googleapis/release-please/tree/main) to automate our releases using conventional commit titles + PRs to create tags + GH releases. 
* Updates our lint workflow to break out the various jobs
* Adds a new lint job for enforcing conventional commit titles

## why
* All updates and additions are to further improve our operations for managing this TF module

## references
* [INT-0: Automated releases on merge to main](https://www.notion.so/masterpoint/Automated-releases-on-merge-to-main-556ae2c35ce444fc8f786fd6a1e1b4bb?pvs=4)

