### PR TITLE
feat(INT-52): add GHA to sync issues to Notion DB

### DIFF
--- a/.github/workflows/notion-sync.yaml
+++ b/.github/workflows/notion-sync.yaml
@@ -1,0 +1,30 @@
+name: Notion Sync
+
+permissions:
+  issues: read
+
+on:
+  workflow_dispatch:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+      - milestoned
+      - demilestoned
+      - reopened
+      - closed
+
+jobs:
+  notion_job:
+    runs-on: ubuntu-latest
+    name: Add GitHub Issues to Notion
+    steps:
+      - name: Add GitHub Issues to Notion
+        uses: tryfabric/notion-github-action@10c6b128faeb9a1f16efc65a0b388b7595047e62
+        with:
+          notion-token: ${{ secrets.GH_ISSUES_NOTION_TOKEN }}
+          notion-db: ${{ secrets.GH_ISSUES_DB_ID }}


### PR DESCRIPTION
## what
* add GHA to sync Github Issues to MP's Notion DB for open source issues

## why

## references
* [INT-52](https://www.notion.so/masterpoint/Create-automation-for-Masterpoint-GH-issues-creating-Notion-tickets-auto-assign-to-a-team-member--c51a716979fe44f7a0163a1c3353f9ef)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a workflow to automatically sync GitHub issues with a Notion database, triggered by various issue events and manual dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->