### PR TITLE
feat: Expose the "architecture" variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ module "tailscale_subnet_router" {
   session_logging_ssm_document_name = var.session_logging_ssm_document_name
 
   ami              = var.ami
+  architecture     = var.architecture
   instance_type    = var.instance_type
   max_size         = var.max_size
   min_size         = var.min_size

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "ami" {
   EOF
 }
 
+variable "architecture" {
+  default     = "arm64"
+  type        = string
+  description = "The architecture of the AMI (e.g., x86_64, arm64)"
+}
+
 variable "instance_type" {
   default     = "t4g.nano"
   type        = string


### PR DESCRIPTION
## what

- This PR exposes the "architecture" variable, as used by the underlying module: https://github.com/masterpointio/terraform-aws-ssm-agent/blob/main/variables.tf#L33

## why

- Currently, the module works with ARM architecture by default ("arm64"). If anyone tries to specify a x86 AMI (e.g. an Ubuntu server), the following error is raised:

```
╷
│ Error: Resource precondition failed
│
│   on .terraform/modules/tailscale.tailscale_subnet_router/main.tf line 18, in resource "null_resource" "validate_instance_type":
│   18:       condition     = local.is_instance_compatible
│     ├────────────────
│     │ local.is_instance_compatible is false
│
│ The instance_type must be compatible with the specified architecture. For x86_64, you cannot use instance types with ARM processors (e.g., t3, m5, c5). For arm64, use instance types with 'g' indicating ARM processor (e.g., t4g, c6g,
│ m6g).

```
- The error comes from a check in the following line of the underlying module that verifies compatibility of the architecture and the chosen AMI: https://github.com/masterpointio/terraform-aws-ssm-agent/blob/main/main.tf#L18

## references

- Underlying module: https://github.com/masterpointio/terraform-aws-ssm-agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable option to specify the architecture (e.g., x86_64, arm64) for the subnet router instance.
  - Default architecture is set to arm64, with the ability to override as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->