### PR TITLE
chore: Upgrade modules to address provider deprecations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 locals {
-
   primary_tag              = coalesce(var.primary_tag, module.this.id)
   prefixed_primary_tag     = "tag:${local.primary_tag}"
   prefixed_additional_tags = [for tag in var.additional_tags : "tag:${tag}"]
@@ -37,7 +36,7 @@ locals {
 # trivy:ignore:AVD-AWS-0090
 module "tailscale_subnet_router" {
   source  = "masterpointio/ssm-agent/aws"
-  version = "1.4.0"
+  version = "1.8.0"
 
   context = module.this.context
   tags    = module.this.tags
@@ -99,7 +98,7 @@ module "ssm_state" {
 module "ssm_policy" {
   count   = var.ssm_state_enabled ? 1 : 0
   source  = "cloudposse/iam-policy/aws"
-  version = "2.0.1"
+  version = "2.0.2"
 
   name        = var.ssm_policy_name
   description = "Additional SSM access for SSM Agent of ${module.this.id} subnet router."

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -58,7 +58,7 @@ run "test_local_userdata_rendered_template" {
   command = apply # because we need access to the tailscale_tailnet_key.default.key value
 
   variables {
-    primary_tag = "test-router"
+    primary_tag     = "test-router"
     additional_tags = ["test-tag1", "test-tag2"]
   }
 
@@ -74,7 +74,7 @@ run "test_local_userdata_rendered_template" {
 
   # Ensure userdata script contains transformed additional tags
   assert {
-    condition = strcontains(local.userdata, "tag:test-tag1") && strcontains(local.userdata, "tag:test-tag2")
+    condition     = strcontains(local.userdata, "tag:test-tag1") && strcontains(local.userdata, "tag:test-tag2")
     error_message = "Expected userdata to contain additional tags"
   }
 }
@@ -88,7 +88,7 @@ run "test_tailscaled_extra_flags" {
 
   # Test that tailscaled_extra_flags are rendered in userdata
   assert {
-    condition = strcontains(local.userdata, "--state=mem:") && strcontains(local.userdata, "--verbose=1")
+    condition     = strcontains(local.userdata, "--state=mem:") && strcontains(local.userdata, "--verbose=1")
     error_message = "Expected userdata to contain tailscaled extra flags"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
     tailscale = {
       source  = "tailscale/tailscale"


### PR DESCRIPTION
## what

- Upgrades `masterpointio/ssm-agent/aws` to v1.8.0 to address AWS provider deprecations:
```
on .terraform/modules/tailscale.tailscale_subnet_router/main.tf line 41, in locals:
│   41:   region     = coalesce(var.region, data.aws_region.current.name)
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
```

- Bump AWS provider required version to >= 5.0 (matching the SSM agent module)

## why

Fix AWS provider deprecation warnings.

## references




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SSM Agent module to version 1.8.0
  * Updated IAM Policy module to version 2.0.2
  * Upgraded AWS provider requirement to version 5.0 or later

<!-- end of auto-generated comment: release notes by coderabbit.ai -->