### PR TITLE
chore: allow to tune logs bucket traffic security policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,9 @@ module "tailscale_subnet_router" {
   session_logging_enabled           = var.session_logging_enabled
   session_logging_ssm_document_name = var.session_logging_ssm_document_name
 
+  allow_ssl_requests_only      = var.allow_ssl_requests_only
+  allow_encrypted_uploads_only = var.allow_encrypted_uploads_only
+
   ami              = var.ami
   architecture     = var.architecture
   instance_type    = var.instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,18 @@ variable "session_logging_ssm_document_name" {
   EOF
 }
 
+variable "allow_ssl_requests_only" {
+  description = "Whether or not to allow SSL requests only. If set to `true` this will create a bucket policy that `Deny` if SSL is not used in the requests using the `aws:SecureTransport` condition."
+  type        = bool
+  default     = false
+}
+
+variable "allow_encrypted_uploads_only" {
+  description = "Whether or not to allow encrypted uploads only. If set to `true` this will create a bucket policy that `Deny` if encryption header is missing in the requests."
+  type        = bool
+  default     = false
+}
+
 variable "key_pair_name" {
   default     = null
   type        = string


### PR DESCRIPTION
## what

- Allow to set both `allow_ssl_requests_only` and `allow_encrypted_uploads_only` in order to configure it at the underlying S3 bucket level.

## why

- We must enable secured traffic for compliance purposes.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allow_ssl_requests_only` configuration option to enforce SSL-only requests
  * Added `allow_encrypted_uploads_only` configuration option to require encrypted uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->