### PR TITLE
chore: add minimumReleaseAge to Renovate conf (INT-356)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,10 +3,14 @@
     "config:best-practices",
     "github>aquaproj/aqua-renovate-config#2.7.5"
   ],
+  "minimumReleaseAge": "3 days",
   "enabledManagers": [
     "terraform",
     "github-actions"
   ],
+  "github-actions": {
+    "pinDigests": true
+  },
   "terraform": {
     "ignorePaths": [
       "**/context.tf" // Mixin file https://github.com/cloudposse/terraform-null-label/blob/main/exports/context.tf

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,9 +8,6 @@
     "terraform",
     "github-actions"
   ],
-  "github-actions": {
-    "pinDigests": true
-  },
   "terraform": {
     "ignorePaths": [
       "**/context.tf" // Mixin file https://github.com/cloudposse/terraform-null-label/blob/main/exports/context.tf


### PR DESCRIPTION
## what

Set `minimumReleaseAge`: `3 days` globally so Renovate waits 3 days after any release before opening an upgrade PR. This applies to all managed dependency types.

## why

The `minimumReleaseAge` window gives the community time to discover and report bugs or vulnerabilities in newly published releases before we adopt them. Without it, Renovate could open a PR for a release within minutes of it being published — before any post-release issues are known.

## references

- [INT-356](https://www.notion.so/masterpoint/Update-Renovate-configs-with-minimumReleaseAge-and-pinDigests-168a707e8c564134b3586fd6a2553233)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce a 3-day minimum age before applying package updates and strengthen stability controls for build system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->