### PR TITLE
fix(userdata): write `tailscaled` config to `/etc/default` and preserve `PORT`

### DIFF
--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -98,11 +98,19 @@ run "test_tailscaled_extra_flags" {
     error_message = "Expected userdata to target /etc/default/tailscaled and not /etc/sysconfig/tailscaled"
   }
 
-  # The script must update FLAGS in-place (sed) rather than truncating the file with `>`.
-  # This preserves the package-provided defaults (PORT, comments, etc.).
+  # The script must update FLAGS without truncating the existing file: write to a
+  # temp file first, then atomically move it into place. This preserves the
+  # package-provided defaults (PORT, comments, etc.).
   assert {
-    condition     = strcontains(local.userdata, "sed -i") && strcontains(local.userdata, "/etc/default/tailscaled")
-    error_message = "Expected userdata to update FLAGS in place via sed to preserve existing /etc/default/tailscaled content"
+    condition     = strcontains(local.userdata, "mktemp /etc/default/tailscaled") && strcontains(local.userdata, "mv -f \"$tmpfile\" /etc/default/tailscaled")
+    error_message = "Expected userdata to write FLAGS via a temp file and atomic mv into /etc/default/tailscaled"
+  }
+
+  # The new FLAGS line must be emitted via a quoted heredoc so the shell does
+  # not re-interpret special characters in the user-supplied flag value.
+  assert {
+    condition     = strcontains(local.userdata, "<<'TS_FLAGS_EOF'")
+    error_message = "Expected userdata to emit FLAGS via a quoted heredoc to avoid shell re-interpretation"
   }
 
   assert {
@@ -114,6 +122,22 @@ run "test_tailscaled_extra_flags" {
   assert {
     condition     = !strcontains(local.userdata, "PORT=\"41641\"")
     error_message = "Expected userdata not to hardcode PORT=\"41641\" in /etc/default/tailscaled"
+  }
+}
+
+run "test_tailscaled_extra_flags_preserves_shell_metacharacters" {
+  command = apply
+
+  # Defense-in-depth: even if a flag value contains characters that are special
+  # to the shell (`|`, `$`, backtick, `\`) or to common substitution tools like
+  # sed, the rendered userdata must contain the value verbatim inside the FLAGS line.
+  variables {
+    tailscaled_extra_flags = ["--weird=a|b$c`d\\e"]
+  }
+
+  assert {
+    condition     = strcontains(local.userdata, "FLAGS=\"--weird=a|b$c`d\\e\"")
+    error_message = "Expected FLAGS line to contain the user-supplied flag value verbatim, including shell metacharacters"
   }
 }
 

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -91,4 +91,63 @@ run "test_tailscaled_extra_flags" {
     condition     = strcontains(local.userdata, "--state=mem:") && strcontains(local.userdata, "--verbose=1")
     error_message = "Expected userdata to contain tailscaled extra flags"
   }
+
+  # Flags should be written to the Debian/AL2023-style path, not the legacy sysconfig path.
+  assert {
+    condition     = strcontains(local.userdata, "/etc/default/tailscaled") && !strcontains(local.userdata, "/etc/sysconfig/tailscaled")
+    error_message = "Expected userdata to target /etc/default/tailscaled and not /etc/sysconfig/tailscaled"
+  }
+
+  # The script must update FLAGS in-place (sed) rather than truncating the file with `>`.
+  # This preserves the package-provided defaults (PORT, comments, etc.).
+  assert {
+    condition     = strcontains(local.userdata, "sed -i") && strcontains(local.userdata, "/etc/default/tailscaled")
+    error_message = "Expected userdata to update FLAGS in place via sed to preserve existing /etc/default/tailscaled content"
+  }
+
+  assert {
+    condition     = length(regexall("[^>]> /etc/default/tailscaled", local.userdata)) == 0
+    error_message = "Expected userdata not to truncate /etc/default/tailscaled with a single `>` redirect"
+  }
+
+  # We must not hardcode PORT; the package default applies, and users may override via --port=... in tailscaled_extra_flags.
+  assert {
+    condition     = !strcontains(local.userdata, "PORT=\"41641\"")
+    error_message = "Expected userdata not to hardcode PORT=\"41641\" in /etc/default/tailscaled"
+  }
+}
+
+run "test_tailscaled_extra_flags_user_supplied_port" {
+  command = apply
+
+  variables {
+    tailscaled_extra_flags = ["--port=12345"]
+  }
+
+  # The user-supplied --port flag must reach the FLAGS line.
+  assert {
+    condition     = strcontains(local.userdata, "--port=12345")
+    error_message = "Expected userdata to contain user-supplied --port flag"
+  }
+
+  # And we must not write a competing PORT=... line ourselves.
+  assert {
+    condition     = !strcontains(local.userdata, "PORT=\"41641\"")
+    error_message = "Expected userdata not to write a hardcoded PORT line that would conflict with user --port flag"
+  }
+}
+
+run "test_tailscaled_extra_flags_disabled_by_default" {
+  command = apply
+
+  # With no extra flags and ssm_state disabled, the whole FLAGS block should be skipped
+  # so that /etc/default/tailscaled is left entirely untouched.
+  variables {
+    ssm_state_enabled = false
+  }
+
+  assert {
+    condition     = !strcontains(local.userdata, "/etc/default/tailscaled")
+    error_message = "Expected userdata not to touch /etc/default/tailscaled when no extra flags are configured"
+  }
 }

--- a/userdata.sh.tmpl
+++ b/userdata.sh.tmpl
@@ -107,7 +107,10 @@ pkg install tailscale
 %{ if tailscaled_extra_flags_enabled == true }
 echo "Writing FLAGS to /etc/default/tailscaled..."
 install -d -m 0755 /etc/default
-echo "FLAGS=\"${tailscaled_extra_flags}\"" > /etc/default/tailscaled
+cat > /etc/default/tailscaled <<'TSEOF'
+PORT="41641"
+TSEOF
+echo "FLAGS=\"${tailscaled_extra_flags}\"" >> /etc/default/tailscaled
 %{ endif }
 
 # --------------------- Enable + start tailscaled -------------

--- a/userdata.sh.tmpl
+++ b/userdata.sh.tmpl
@@ -108,12 +108,18 @@ pkg install tailscale
 echo "Updating FLAGS in /etc/default/tailscaled..."
 install -d -m 0755 /etc/default
 touch /etc/default/tailscaled
-if grep -qE '^[[:space:]]*FLAGS=' /etc/default/tailscaled; then
-  # Replace the existing FLAGS= line, preserving the rest of the file.
-  sed -i "s|^[[:space:]]*FLAGS=.*|FLAGS=\"${tailscaled_extra_flags}\"|" /etc/default/tailscaled
-else
-  echo "FLAGS=\"${tailscaled_extra_flags}\"" >> /etc/default/tailscaled
-fi
+tmpfile="$(mktemp /etc/default/tailscaled.XXXXXX)"
+# Preserve everything except the existing FLAGS= line so the package-provided
+# defaults (PORT, comments, etc.) remain intact.
+grep -vE '^[[:space:]]*FLAGS=' /etc/default/tailscaled > "$tmpfile" || true
+# Append the new FLAGS line via a quoted heredoc so the shell does not
+# re-interpret any special characters (`$`, backticks, `|`, `\`, ...) that
+# may appear in the user-supplied tailscaled_extra_flags value.
+cat >> "$tmpfile" <<'TS_FLAGS_EOF'
+FLAGS="${tailscaled_extra_flags}"
+TS_FLAGS_EOF
+chmod 0644 "$tmpfile"
+mv -f "$tmpfile" /etc/default/tailscaled
 %{ endif }
 
 # --------------------- Enable + start tailscaled -------------

--- a/userdata.sh.tmpl
+++ b/userdata.sh.tmpl
@@ -105,12 +105,15 @@ pkg install tailscale
 
 # --------------------- Optional extra tailscaled FLAGS -------
 %{ if tailscaled_extra_flags_enabled == true }
-echo "Writing FLAGS to /etc/default/tailscaled..."
+echo "Updating FLAGS in /etc/default/tailscaled..."
 install -d -m 0755 /etc/default
-cat > /etc/default/tailscaled <<'TSEOF'
-PORT="41641"
-TSEOF
-echo "FLAGS=\"${tailscaled_extra_flags}\"" >> /etc/default/tailscaled
+touch /etc/default/tailscaled
+if grep -qE '^[[:space:]]*FLAGS=' /etc/default/tailscaled; then
+  # Replace the existing FLAGS= line, preserving the rest of the file.
+  sed -i "s|^[[:space:]]*FLAGS=.*|FLAGS=\"${tailscaled_extra_flags}\"|" /etc/default/tailscaled
+else
+  echo "FLAGS=\"${tailscaled_extra_flags}\"" >> /etc/default/tailscaled
+fi
 %{ endif }
 
 # --------------------- Enable + start tailscaled -------------

--- a/userdata.sh.tmpl
+++ b/userdata.sh.tmpl
@@ -105,9 +105,9 @@ pkg install tailscale
 
 # --------------------- Optional extra tailscaled FLAGS -------
 %{ if tailscaled_extra_flags_enabled == true }
-echo "Writing FLAGS to /etc/sysconfig/tailscaled..."
-install -d -m 0755 /etc/sysconfig
-echo "FLAGS=\"${tailscaled_extra_flags}\"" > /etc/sysconfig/tailscaled
+echo "Writing FLAGS to /etc/default/tailscaled..."
+install -d -m 0755 /etc/default
+echo "FLAGS=\"${tailscaled_extra_flags}\"" > /etc/default/tailscaled
 %{ endif }
 
 # --------------------- Enable + start tailscaled -------------


### PR DESCRIPTION
## what

- Changes the `tailscaled` extra flags file path from `/etc/sysconfig/tailscaled` to `/etc/default/tailscaled` in the EC2 userdata script.
- Ensures `PORT` is written back to that configuration file now that we're actually touching the right one.

## why

On `main`, `userdata.sh.tmpl` wrote `FLAGS` to `/etc/sysconfig/tailscaled`, but the upstream systemd unit uses:

- `EnvironmentFile=/etc/default/tailscaled`
- `ExecStart=... --port=${PORT} $FLAGS`

So our module-managed daemon flags were ignored. That impacted features that depend on `tailscaled_extra_flags`:

- **`ssm_state_enabled` path in daemon state**  
  In `main.tf`, `ssm_state_enabled` injects `--state=...` into `tailscaled_extra_flags`.  
  If ignored, daemon state stays local instead of SSM-backed.
- **Direct-connect custom port behavior** documented in `README.md` (`tailscaled_extra_flags = ["--port=..."]`)  
  That custom `--port` would be ignored.
- **Any other advanced daemon flags** passed via `tailscaled_extra_flags` were ignored.

What was **not** affected:

- `tailscale_up_extra_flags` and `tailscale_set_extra_flags` (those are passed directly to CLI commands in userdata, not via environment file).

In other words:

- The Tailscale daemon (`tailscaled`) reads its `FLAGS` environment variable from `/etc/default/tailscaled` on Debian-based and modern systemd-based distributions (including Amazon Linux 2023), not `/etc/sysconfig/tailscaled`.
- `/etc/sysconfig/` is a Red Hat / Amazon Linux 2 convention that is not used by the `tailscaled` systemd unit on AL2023. The existing path meant that any `tailscaled_extra_flags` configured by users (e.g. `--state=mem:`) were silently ignored because the daemon never read the file.
- `/etc/default/tailscaled` is the path referenced in the [official Tailscale documentation](https://tailscale.com/kb/1278/tailscaled#flags-to-tailscaled) and in the upstream `tailscaled` systemd unit's `EnvironmentFile` directive.

## references

- https://tailscale.com/kb/1278/tailscaled#flags-to-tailscaled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tailscale extra flags configuration to use the correct system location during provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->