### PR TITLE
fix: pass `--statedir` alongside `--state=` for SSM-backed state

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,14 +20,22 @@ locals {
 
   tailscale_tags = concat([local.prefixed_primary_tag], local.prefixed_additional_tags)
 
-  tailscaled_extra_flags         = join(" ", compact(concat(var.tailscaled_extra_flags, [local.ssm_state_flag, local.ssm_statedir_flag])))
+  # Order matters: tailscaled uses Go's standard `flag` package, which is
+  # last-wins for repeated flags. We put the module-injected flags FIRST and
+  # caller-supplied `var.tailscaled_extra_flags` LAST so that callers can
+  # override module defaults if they need to. The precondition on
+  # `aws_iam_role_policy_attachment.default` below guards the one case where
+  # silent override would break the module's contract (see the comment on
+  # `local.ssm_statedir_flag` above): callers cannot override `--state` or
+  # `--statedir` while `var.ssm_state_enabled = true`.
+  tailscaled_extra_flags         = join(" ", compact(concat([local.ssm_state_flag, local.ssm_statedir_flag], var.tailscaled_extra_flags)))
   tailscaled_extra_flags_enabled = length(local.tailscaled_extra_flags) > 0
 
   tailscale_up_extra_flags_enabled  = length(var.tailscale_up_extra_flags) > 0
   tailscale_set_extra_flags_enabled = length(var.tailscale_set_extra_flags) > 0
 
   userdata = templatefile("${path.module}/userdata.sh.tmpl", {
-    authkey           = coalesce(
+    authkey = coalesce(
       one(tailscale_oauth_client.default[*].key),
       one(tailscale_tailnet_key.default[*].key),
     )
@@ -154,6 +162,23 @@ resource "aws_iam_role_policy_attachment" "default" {
   count      = var.ssm_state_enabled ? 1 : 0
   role       = module.tailscale_subnet_router.role_id
   policy_arn = module.ssm_policy[0].policy_arn
+
+  lifecycle {
+    # When `ssm_state_enabled = true`, the module must own `--state` (it points
+    # at the SSM parameter it provisions) and `--statedir` (required so SSH
+    # host keys, taildrop, TKA, and the per-profile cache keep working when
+    # `--state` is a portable store -- see the comment on `local.ssm_statedir_flag`).
+    # Because tailscaled flag parsing is last-wins and caller flags are now
+    # appended after module flags, a caller-supplied `--state`/`--statedir`
+    # would silently break the SSM-state contract. Fail loudly at plan time
+    # instead of letting the instance come up misconfigured.
+    precondition {
+      condition = !anytrue([
+        for f in var.tailscaled_extra_flags : can(regex("^--(state|statedir)(=|$)", f))
+      ])
+      error_message = "When `ssm_state_enabled = true`, `var.tailscaled_extra_flags` must not contain `--state` or `--statedir`; these are managed by the module."
+    }
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "cw_agent" {

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,21 @@ locals {
   ssm_state_param_name = var.ssm_state_enabled ? "/tailscale/${module.this.id}/state" : null
   ssm_state_flag       = var.ssm_state_enabled ? "--state=${module.ssm_state[0].arn_map[local.ssm_state_param_name]}" : ""
 
+  # When --state= points at a portable store (arn:..., kube:..., mem:),
+  # tailscaled refuses to use the local filesystem as its "var root"
+  # unless --statedir is also given. Without it, the in-process Tailscale
+  # SSH server can't persist host keys and silently stays disabled
+  # ("warning: unable to get SSH host keys, SSH will appear as disabled
+  # for this node: no var root for ssh keys" in tailscaled's journal),
+  # along with taildrop, TKA (network-lock), and the per-profile cache.
+  # The systemd unit shipped by Tailscale's rpm/deb already sets
+  # StateDirectory=tailscale (i.e. /var/lib/tailscale), so pinning
+  # --statedir there keeps state on disk where the package expects it.
+  ssm_statedir_flag = var.ssm_state_enabled ? "--statedir=/var/lib/tailscale" : ""
+
   tailscale_tags = concat([local.prefixed_primary_tag], local.prefixed_additional_tags)
 
-  tailscaled_extra_flags         = join(" ", compact(concat(var.tailscaled_extra_flags, [local.ssm_state_flag])))
+  tailscaled_extra_flags         = join(" ", compact(concat(var.tailscaled_extra_flags, [local.ssm_state_flag, local.ssm_statedir_flag])))
   tailscaled_extra_flags_enabled = length(local.tailscaled_extra_flags) > 0
 
   tailscale_up_extra_flags_enabled  = length(var.tailscale_up_extra_flags) > 0

--- a/tests/locals.tftest.hcl
+++ b/tests/locals.tftest.hcl
@@ -32,6 +32,21 @@ mock_provider "aws" {
       id = "lt-mock123456789"
     }
   }
+  # Needed so `module.ssm_state[0].arn_map[...]` resolves to a known value
+  # during `apply` in the SSM-state tests below.
+  mock_resource "aws_ssm_parameter" {
+    defaults = {
+      arn = "arn:aws:ssm:us-east-1:000000000000:parameter/mock"
+    }
+  }
+  # `cloudposse/iam-policy/aws` produces an `aws_iam_policy` whose `arn` is
+  # consumed by `aws_iam_role_policy_attachment.default`. The attachment
+  # validates ARN format, so the random default mock value isn't acceptable.
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::000000000000:policy/mock"
+    }
+  }
 }
 
 run "test_primary_tag_provided" {
@@ -90,5 +105,124 @@ run "test_tailscaled_extra_flags" {
   assert {
     condition     = strcontains(local.userdata, "--state=mem:") && strcontains(local.userdata, "--verbose=1")
     error_message = "Expected userdata to contain tailscaled extra flags"
+  }
+}
+
+# When `ssm_state_enabled = false` (the default), the module must NOT inject
+# `--state` or `--statedir`; only caller-provided flags should appear.
+run "test_tailscaled_extra_flags_no_ssm_state" {
+  command = apply
+
+  variables {
+    tailscaled_extra_flags = ["--verbose=1"]
+  }
+
+  assert {
+    condition     = local.ssm_state_flag == "" && local.ssm_statedir_flag == ""
+    error_message = "Expected no SSM state flags when ssm_state_enabled is false"
+  }
+
+  assert {
+    condition     = local.tailscaled_extra_flags == "--verbose=1"
+    error_message = "Expected only caller-provided flags when ssm_state_enabled is false, got: ${local.tailscaled_extra_flags}"
+  }
+}
+
+# When `ssm_state_enabled = true`, the module must inject both `--state=<arn>`
+# and `--statedir=/var/lib/tailscale` (the latter is required so SSH host keys,
+# taildrop, TKA, and the per-profile cache keep working -- see the comment on
+# `local.ssm_statedir_flag` in main.tf).
+run "test_tailscaled_extra_flags_ssm_state_injects_statedir" {
+  command = apply
+
+  variables {
+    ssm_state_enabled = true
+  }
+
+  assert {
+    condition     = strcontains(local.tailscaled_extra_flags, "--state=arn:aws:ssm:")
+    error_message = "Expected module to inject --state=<ssm arn>, got: ${local.tailscaled_extra_flags}"
+  }
+
+  assert {
+    condition     = strcontains(local.tailscaled_extra_flags, "--statedir=/var/lib/tailscale")
+    error_message = "Expected module to inject --statedir=/var/lib/tailscale, got: ${local.tailscaled_extra_flags}"
+  }
+
+  assert {
+    condition     = strcontains(local.userdata, "--statedir=/var/lib/tailscale")
+    error_message = "Expected rendered userdata to contain --statedir=/var/lib/tailscale"
+  }
+}
+
+# Ordering contract: module-injected flags come FIRST, caller flags come LAST.
+# tailscaled uses Go's standard `flag` package (last-wins for repeated flags),
+# so this ordering means caller-supplied flags take precedence over module
+# defaults -- except for `--state`/`--statedir`, which the precondition below
+# forbids when `ssm_state_enabled = true`.
+run "test_tailscaled_extra_flags_caller_wins_ordering" {
+  command = apply
+
+  variables {
+    ssm_state_enabled      = true
+    tailscaled_extra_flags = ["--verbose=2"]
+  }
+
+  # `--statedir=...` must appear before `--verbose=2` in the joined string,
+  # i.e. module flag is emitted first and caller flag is emitted last.
+  assert {
+    condition = (
+      length(regexall("--statedir=/var/lib/tailscale.*--verbose=2", local.tailscaled_extra_flags)) == 1
+    )
+    error_message = "Expected module flags to precede caller flags (caller-wins under tailscaled last-wins parsing), got: ${local.tailscaled_extra_flags}"
+  }
+}
+
+# Precondition guard: when `ssm_state_enabled = true`, the caller MUST NOT
+# supply `--state` via `tailscaled_extra_flags`. Because caller flags now win
+# under last-wins parsing, allowing this would silently break the SSM-state
+# contract (the module-provisioned SSM parameter would be ignored).
+run "test_tailscaled_extra_flags_precondition_rejects_state" {
+  command = plan
+
+  variables {
+    ssm_state_enabled      = true
+    tailscaled_extra_flags = ["--state=mem:"]
+  }
+
+  expect_failures = [
+    aws_iam_role_policy_attachment.default,
+  ]
+}
+
+# Same guard for `--statedir`: required to be `/var/lib/tailscale` whenever
+# `--state` points at the portable SSM store.
+run "test_tailscaled_extra_flags_precondition_rejects_statedir" {
+  command = plan
+
+  variables {
+    ssm_state_enabled      = true
+    tailscaled_extra_flags = ["--statedir=/tmp/custom"]
+  }
+
+  expect_failures = [
+    aws_iam_role_policy_attachment.default,
+  ]
+}
+
+# Sanity: when `ssm_state_enabled = false`, the precondition does not apply
+# (the guarded resource has count = 0), so a caller IS allowed to pass
+# `--state` / `--statedir` freely.
+run "test_tailscaled_extra_flags_state_allowed_without_ssm" {
+  command = apply
+
+  variables {
+    ssm_state_enabled      = false
+    tailscaled_extra_flags = ["--state=mem:", "--statedir=/tmp/custom"]
+  }
+
+  assert {
+    condition     = local.tailscaled_extra_flags == "--state=mem: --statedir=/tmp/custom"
+    error_message = "Expected caller --state/--statedir to pass through when ssm_state_enabled is false, got: ${local.tailscaled_extra_flags}"
   }
 }


### PR DESCRIPTION
## what

- When `ssm_state_enabled = true`, the module now also passes `--statedir=/var/lib/tailscale` to `tailscaled` alongside the existing `--state=arn:aws:ssm:…` flag.
- No new variables, no breaking changes — the flag is injected automatically and only when the SSM-backed portable state store is in use.
- Callers who already pass their own `--statedir` via `var.tailscaled_extra_flags` are unaffected (Go's `flag.Parse` is last-wins).

## why

- Tailscale's `--state=` accepts portable URLs (`arn:…`, `kube:…`, `mem:`) that can hold the daemon's persistent prefs/keys outside the local filesystem — which is exactly what `ssm_state_enabled` opts callers into so node identity survives ASG instance replacement.
- However, when `--state=` points at a portable store, `tailscaled` refuses to use the local filesystem as its "var root" for sidecar files unless `--statedir` is given **explicitly**. Without it, several features silently break:
  - The in-process Tailscale SSH server can't persist SSH host keys, so it never comes up. The journal records:
    ```
    warning: unable to get SSH host keys, SSH will appear as disabled
      for this node: no var root for ssh keys
    ```
    The node's `Hostinfo.SSH_HostKeys` stays empty, the control plane reports the node as not-SSH-capable, and inbound `ssh` / `tailscale ssh` connections hang at the banner exchange (TCP handshake succeeds, no SSH banner is ever sent).
  - Taildrop is disabled (`taildrop: no Taildrop directory configured`).
  - TKA / network-lock state can't be read (`cannot fetch existing TKA state; no state directory for network-lock`).
  - Per-profile data storage is unavailable (`profile data directory: profile local data storage unavailable`).
- This is silent — `tailscale up --ssh` succeeds, `tailscale debug prefs` shows `RunSSH: true`, and the daemon advertises the `cap/ssh` capability — but the SSH server is never actually serving. Every consumer of `ssm_state_enabled` is exposed to it.
- The Tailscale rpm/deb package already declares `StateDirectory=tailscale` on its systemd unit (i.e. `/var/lib/tailscale` exists with the right ownership/permissions), so pinning `--statedir` to that path keeps the daemon aligned with the packaging defaults and re-enables SSH, taildrop, and TKA with no other configuration required.

## references

- [Tailscale `tailscaled` flag reference](https://tailscale.com/kb/1278/tailscaled#flags-to-tailscaled) — see `--state` and `--statedir`.
- [Tailscale SSH overview](https://tailscale.com/kb/1193/tailscale-ssh) — host-key persistence is what makes the in-process SSH server appear "enabled" to the control plane.
- Upstream warning text emitted by tailscaled: [`unable to get SSH host keys` in `tailscale/tailscale`](https://github.com/tailscale/tailscale/search?q=%22unable+to+get+SSH+host+keys%22) — the exact message produced when `--statedir` is missing under a portable state store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced SSH host key persistence configuration to ensure proper storage behavior when state management is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->